### PR TITLE
INDY-796 Release Notes for Sovrin Aries 1.0.4

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -8,12 +8,59 @@
 
 
 
-## Aries 1.0
+
 
 
 #### Disclosure
 
 Although every attempt has been made to make this information as accurate as possible, please know there may be things that are omitted, not fully developed yet, or updates since this publication that were not included in the information below. Only the most pressing or significant items have been listed. For the entire list of tickets and or specific information about any given item, please visit the list at [Hyperleder Indy's Jira](https://jira.hyperledger.org/). Once logged in, simply navigate to Projects > Indy.
+
+
+## Aries 1.0.4
+
+
+Component Version Information
+
+| Components | Version Numbers |
+| --- | --- |
+| indy-plenum | 1.1.24 |
+| indy-anoncreds | 1.0.9 |
+| indy-node | 1.1.31 |
+| sovrin | 1.0.4 |
+|   |   | |
+
+### Major Fixes
+
+| Description | Additional Information | Ticket Number |
+| --- | --- | --- |
+| Stewards can now demote and promote their own nodes. |   | [INDY-410](https://jira.hyperledger.org/browse/INDY-410) |
+| Fixed problem with timezones for timestamp in a transaction. |   | [INDY-466](https://jira.hyperledger.org/browse/INDY-466) |
+| Limited incoming message size from 128k to 128MB (Temporary solution). |   | [INDY-25](https://jira.hyperledger.org/browse/INDY-25) |
+| Fixed `send CLAIM_DEF` command. |   | [INDY-378](https://jira.hyperledger.org/browse/INDY-378) |
+| Masked private information in the CLI logs/output. |   | [INDY-725](https://jira.hyperledger.org/browse/INDY-725) |
+| Fixes crashes on ubuntu 17.04. |   | [INDY-8](https://jira.hyperledger.org/browse/INDY-8) |
+| Python interpreter is executed in optimized mode. |   | [INDY-211](https://jira.hyperledger.org/browse/INDY-211) |
+| Memory leak fixes. |   | [INDY-223](https://jira.hyperledger.org/browse/INDY-223) |
+| Some minor stability fixes. |   |   |
+|   |   |   |   |
+
+### Changes - Additions - Known Issues
+
+| Description | Workaround | Ticket |
+| --- | --- | --- |
+| **New ledger serialization is supported and Leveldb is used as a storage for all ledgers** : msgpack is used for the ledger serialization (both transaction log and merkle tree). |   |   |
+| **The new serialization change created changes to the directory structure for the nodes.** The directory name changes are located on a node under .sovrin/data/nodes/&lt;node name&gt;/&lt;directories&gt;. The change removes the ledger files as plain text files and creates them as binary files. A new tool was created to view the ledger entries called `read_ledger`. This tool also provides you with a count of the transactions. To learn more about this tool and to see a list of available commands, run this as the sovrin user: `read_ledger --h` | | |
+| **Genesis transaction files are renamed adding a \_genesis to the end of each file name.** |   |   |
+| **Added the commands to the POOL\_UPGRADE to support downgrade and re-installation.** However both have issues and should not be used at this time. |   | [INDY-735](https://jira.hyperledger.org/browse/INDY-735) [INDY-755](https://jira.hyperledger.org/browse/INDY-755) |
+| **Fixes to upgrade procedure, in particular an issue which caused an infinite loop.** |   | [INDY-316](https://jira.hyperledger.org/browse/INDY-316) |
+| **A new CLI command was added to ease the process of rotating a verification key (verkey).** The command is `change current key` or `change current key with seed xxxxx`. |   |   |
+| **Improvements to log messages.** |   |   |
+| **Publishing only to repo.sovrin.org** |   |   |
+|  In your sources.list you only need the entry &quot;deb https://repo.evernym.com/deb xenial stable&quot;. |   |   |
+|   |   |   |
+
+
+## Aries 1.0
 
 
 ### Major Features

--- a/release-notes.md
+++ b/release-notes.md
@@ -11,12 +11,22 @@
 
 
 
+
+* [Aries 1.1.6](#aries-1.1.6)
+
+* [Aries 1.0](#aries-1.0)
+
+
+
+
+
+
 #### Disclosure
 
 Although every attempt has been made to make this information as accurate as possible, please know there may be things that are omitted, not fully developed yet, or updates since this publication that were not included in the information below. Only the most pressing or significant items have been listed. For the entire list of tickets and or specific information about any given item, please visit the list at [Hyperleder Indy's Jira](https://jira.hyperledger.org/). Once logged in, simply navigate to Projects > Indy.
 
 
-## Aries 1.0.4
+## Aries 1.1.6
 
 
 Component Version Information
@@ -24,9 +34,9 @@ Component Version Information
 | Components | Version Numbers |
 | --- | --- |
 | indy-plenum | 1.1.24 |
-| indy-anoncreds | 1.0.9 |
-| indy-node | 1.1.31 |
-| sovrin | 1.0.4 |
+| indy-anoncreds | 1.0.10 |
+| indy-node | 1.1.33 |
+| sovrin | 1.1.6 |
 |   |   | |
 
 ### Major Fixes


### PR DESCRIPTION
Adding the release notes for Sovrin Aries build 1.0.4. Placed Aries 1.0.4 on top of Aries 1.0 and moved headings to reflect as such. 