### PR TITLE
INDY-580: Improve packaging before supporting CentOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,9 @@ def name = 'sovrin'
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "sovrin-deb-u1604"
-    sh "docker volume rm -f $volumeName"
+    if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
+	sh "docker volume rm $volumeName"
+    }
     dir('build-scripts/ubuntu-1604') {
         sh "./build-sovrin-docker.sh $sourcePath $releaseVersion"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
 	sh "docker volume rm $volumeName"
     }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-sovrin-docker.sh $sourcePath $releaseVersion"
+        sh "./build-sovrin-docker.sh \"$sourcePath\" $releaseVersion"
     }
     return "$volumeName"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ def name = 'sovrin'
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "sovrin-deb-u1604"
+    if ("${BRANCH_NAME}" != '' && "${BRANCH_NAME}" != 'master') volumeName = "${volumeName}.${BRANCH_NAME}"
     if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
 	sh "docker volume rm $volumeName"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,11 @@ def name = 'sovrin'
 
 def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
     def volumeName = "sovrin-deb-u1604"
-    if ("${BRANCH_NAME}" != '' && "${BRANCH_NAME}" != 'master') volumeName = "${volumeName}.${BRANCH_NAME}"
+    if (env.BRANCH_NAME != '' && env.BRANCH_NAME != 'master') {
+        volumeName = "${volumeName}.${BRANCH_NAME}"
+    }
     if (sh(script: "docker volume ls -q | grep -q '^$volumeName\$'", returnStatus: true) == 0) {
-	sh "docker volume rm $volumeName"
+        sh "docker volume rm $volumeName"
     }
     dir('build-scripts/ubuntu-1604') {
         sh "./build-sovrin-docker.sh \"$sourcePath\" $releaseVersion $volumeName"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def buildDebUbuntu = { repoName, releaseVersion, sourcePath ->
 	sh "docker volume rm $volumeName"
     }
     dir('build-scripts/ubuntu-1604') {
-        sh "./build-sovrin-docker.sh \"$sourcePath\" $releaseVersion"
+        sh "./build-sovrin-docker.sh \"$sourcePath\" $releaseVersion $volumeName"
     }
     return "$volumeName"
 }

--- a/build-scripts/ubuntu-1604/build-sovrin-docker.sh
+++ b/build-scripts/ubuntu-1604/build-sovrin-docker.sh
@@ -7,7 +7,7 @@ IMAGE_NAME="${PKG_NAME}-build-u1604"
 OUTPUT_VOLUME_NAME="$3"
 
 if [[ (-z "${PKG_SOURCE_PATH}") || (-z "${VERSION}") ]]; then
-    echo "Usage: $0 <path-to-package-sources> <version>"
+    echo "Usage: $0 <path-to-package-sources> <version> <volume>"
     exit 1;
 fi
 

--- a/build-scripts/ubuntu-1604/build-sovrin-docker.sh
+++ b/build-scripts/ubuntu-1604/build-sovrin-docker.sh
@@ -1,24 +1,24 @@
 #!/bin/bash -xe
 
-PKG_SOURCE_PATH=$1
-VERSION=$2
+PKG_SOURCE_PATH="$1"
+VERSION="$2"
 PKG_NAME=sovrin
-OUTPUT_VOLUME_NAME=${PKG_NAME}-deb-u1604
-IMAGE_NAME=${PKG_NAME}-build-u1604
+IMAGE_NAME="${PKG_NAME}-build-u1604"
+OUTPUT_VOLUME_NAME="$3"
 
-if [[ (-z ${PKG_SOURCE_PATH}) || (-z ${VERSION}) ]]; then
+if [[ (-z "${PKG_SOURCE_PATH}") || (-z "${VERSION}") ]]; then
     echo "Usage: $0 <path-to-package-sources> <version>"
     exit 1;
 fi
 
-if [ -z $3 ]; then
-    CMD="/root/build-"${PKG_NAME}".sh /input ${VERSION} /output"
+if [ -z "$4" ]; then
+    CMD="/root/build-${PKG_NAME}.sh /input ${VERSION} /output"
 else
-    CMD=$3
+    CMD="$4"
 fi
 
-docker build -t ${IMAGE_NAME} -f Dockerfile .
-docker volume create --name ${OUTPUT_VOLUME_NAME}
+docker build -t "${IMAGE_NAME}" -f Dockerfile .
+docker volume create --name "${OUTPUT_VOLUME_NAME}"
 
 docker run \
     -i \

--- a/build-scripts/ubuntu-1604/build-sovrin-docker.sh
+++ b/build-scripts/ubuntu-1604/build-sovrin-docker.sh
@@ -4,7 +4,7 @@ PKG_SOURCE_PATH="$1"
 VERSION="$2"
 PKG_NAME=sovrin
 IMAGE_NAME="${PKG_NAME}-build-u1604"
-OUTPUT_VOLUME_NAME="$3"
+OUTPUT_VOLUME_NAME="${3:-"${PKG_NAME}-deb-u1604"}"
 
 if [[ (-z "${PKG_SOURCE_PATH}") || (-z "${VERSION}") ]]; then
     echo "Usage: $0 <path-to-package-sources> <version> <volume>"

--- a/build-scripts/ubuntu-1604/build-sovrin-docker.sh
+++ b/build-scripts/ubuntu-1604/build-sovrin-docker.sh
@@ -23,9 +23,9 @@ docker volume create --name ${OUTPUT_VOLUME_NAME}
 docker run \
     -i \
     --rm \
-    -v ${PKG_SOURCE_PATH}:/input \
-    -v ${OUTPUT_VOLUME_NAME}:/output \
-    -e PKG_NAME=${PKG_NAME} \
-    ${IMAGE_NAME} \
+    -v "${PKG_SOURCE_PATH}:/input" \
+    -v "${OUTPUT_VOLUME_NAME}:/output" \
+    -e PKG_NAME="${PKG_NAME}" \
+    "${IMAGE_NAME}" \
     $CMD
 


### PR DESCRIPTION
- Work around missing "docker volume rm --force" option in older API (< 1.25). So it also works with docker 1.12 provided with CentOS 7 (should not hurt).
- Quote shell variables to support space in paths (always good).
- Support parallel docker builds by adding suffix to volumes in case of multi-branch pipeline (should not change anything for single-branch).

REM: See other PR's for similar improvements in indy repos (i.e.: for [indy-node](https://github.com/hyperledger/indy-node/pull/381)).