### PR TITLE
Update indy-node, token-plugin and GitHub actions versions

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -20,7 +20,7 @@ jobs:
       testsNeeded: ${{ steps.testsNeeded.outputs.testsNeeded }}
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup
         id: setup
         uses: hyperledger/indy-shared-gha/.github/actions/workflow-setup@v1
@@ -28,7 +28,7 @@ jobs:
           ownerRepo: "sovrin-foundation"
       - name: testsNeeded
         id: testsNeeded
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         with:
           filters: |
             testsNeeded:
@@ -46,9 +46,9 @@ jobs:
       sovtokenfeesVersion: ${{ steps.sovtoken-versions.outputs.sovtokenfeesVersion}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set up python

--- a/.github/workflows/PublishRelease.yaml
+++ b/.github/workflows/PublishRelease.yaml
@@ -32,7 +32,7 @@ jobs:
       publish: ${{ steps.workflow-setup.outputs.publish}}
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: get-release-info
         id: get-release-info
         uses: hyperledger/indy-shared-gha/.github/actions/get-release-info@v1
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download sovrin deb Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: Releasepr.yaml
@@ -61,7 +61,7 @@ jobs:
           name: sovrin-deb
           path: artifacts/sovrin-deb
       - name: Download sovrin python Artifacts from Github Action Artifacts
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: Releasepr.yaml
@@ -69,12 +69,12 @@ jobs:
           name: sovrin-python
           path: artifacts/sovrin-python
       - name: Upload sovrin-deb
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sovrin-deb
           path: artifacts/sovrin-deb
       - name: Upload sovrin-python
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sovrin-python
           path: artifacts/sovrin-python

--- a/.github/workflows/Push.yaml
+++ b/.github/workflows/Push.yaml
@@ -20,7 +20,7 @@ jobs:
       publish: ${{ steps.setup.outputs.publish}}
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup
         id: setup
         uses: hyperledger/indy-shared-gha/.github/actions/workflow-setup@v1
@@ -28,7 +28,7 @@ jobs:
           ownerRepo: "sovrin-foundation"
       - name: testsNeeded
         id: testsNeeded
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         with:
           filters: |
             testsNeeded:
@@ -46,14 +46,14 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.repository-name.outputs.lowercase }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Convert the GitHub repository name to lowercase
         id: repository-name
-        uses: ASzc/change-string-case-action@v5
+        uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ github.repository }}
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set up python

--- a/.github/workflows/Releasepr.yaml
+++ b/.github/workflows/Releasepr.yaml
@@ -17,14 +17,14 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ steps.repository-name.outputs.lowercase }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Convert the GitHub repository name to lowercase
         id: repository-name
-        uses: ASzc/change-string-case-action@v5
+        uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ github.repository }}
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set up python

--- a/.github/workflows/Tag.yaml
+++ b/.github/workflows/Tag.yaml
@@ -16,7 +16,7 @@ jobs:
       BASE: ${{ steps.get-branch.outputs.branch }}
     steps:
       - name: checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: extract branch
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set up python
@@ -49,7 +49,7 @@ jobs:
           python3 updateVersion.py -t ${{ needs.taginfos.outputs.VERSION }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           author: ${{ github.actor }} <${{ github.event.pusher.email }}>
           committer: ${{ github.actor }} <${{ github.event.pusher.email }}>

--- a/.github/workflows/repoDispatchable_updateNodeDependency.yaml
+++ b/.github/workflows/repoDispatchable_updateNodeDependency.yaml
@@ -8,13 +8,13 @@ jobs:
   update-setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Update indy-node to ${{ github.event.client_payload.pyVersion }}
         run: |
           sed -i "s/\(indy-node==\)[^ ]*/\1${{ github.event.client_payload.pyVersion }}',/g" setup.py
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           author: ${{ github.actor }} <${{ github.event.client_payload.email }}>

--- a/.github/workflows/repoDispatchable_updateTokenPluginDependency.yaml
+++ b/.github/workflows/repoDispatchable_updateTokenPluginDependency.yaml
@@ -8,21 +8,21 @@ jobs:
   update-setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Update indy-node to ${{ github.event.client_payload.pyVersion }}
+      - uses: actions/checkout@v4
+      - name: Update token-plugin to ${{ github.event.client_payload.pyVersion }}
         run: |
           sed -i "s/\(sovtoken==\)[^ ]*/\1${{ github.event.client_payload.pyVersion }}',/g" setup.py
           sed -i "s/\(sovtokenfees==\)[^ ]*/\1${{ github.event.client_payload.pyVersion }}',/g" setup.py
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           author: ${{ github.actor }} <${{ github.event.client_payload.email }}>
           signoff: true
           committer: ${{ github.actor }} <${{ github.event.client_payload.email }}>
-          commit-message: "Automated Update to indy-node==${{ github.event.client_payload.pyVersion }}"
-          title: "Automated Update to indy-node==${{ github.event.client_payload.pyVersion }}"
-          body: "This PR updates the indy-node version in `setup.py` to use `indy-node==${{ github.event.client_payload.pyVersion }}`."
+          commit-message: "Automated Update to sovtoken==${{ github.event.client_payload.pyVersion }}"
+          title: "Automated Update to sovtoken==${{ github.event.client_payload.pyVersion }}"
+          body: "This PR updates the token-plugin version in `setup.py` to use `sovtoken==${{ github.event.client_payload.pyVersion }}`."
           branch: "Token-Pluging-Updates"
           delete-branch: true
           base: "master"

--- a/.github/workflows/reuseable_build_package.yaml
+++ b/.github/workflows/reuseable_build_package.yaml
@@ -31,13 +31,13 @@ jobs:
     needs: timestamp
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup
         run: |
           sudo apt-get update && sudo apt-get -y install rubygems
           sudo gem install fpm
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set up python
@@ -55,7 +55,7 @@ jobs:
       - name: Build Sovrin Deb
         run: sudo bash ./build-scripts/ubuntu-2004/build-sovrin.sh "./" "${{ steps.version.outputs.debVersion }}" "$PWD"
       - name: Upload sovrin.deb
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sovrin-deb
           path: ./sovrin_*.deb
@@ -67,9 +67,9 @@ jobs:
     needs: timestamp
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Set up python
@@ -80,7 +80,7 @@ jobs:
         run: python3 updateVersion.py --timestamp ${{ needs.timestamp.outputs.timestamp }}
       - name: Build python sovrin package
         run: python3 setup.py sdist --dist-dir /tmp/dist bdist_wheel --dist-dir /tmp/dist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sovrin-python
           path: /tmp/dist

--- a/.github/workflows/reuseable_publish.yaml
+++ b/.github/workflows/reuseable_publish.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_ENV_1: ${{ secrets.SOVRIN_ARTIFACTORY_REPO_CONFIG }}
 
@@ -38,7 +38,7 @@ jobs:
           jfrog rt ping
 
       - name: Download sovrin-deb package from GHA
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sovrin-deb
           path: /tmp/sovrin-deb/
@@ -52,7 +52,7 @@ jobs:
           repo: "deb"
 
       - name: Download sovrin Python Packages from Pipeline Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sovrin-python
           path: dist

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
              '*.css', '*.ico', '*.png', 'LICENSE', 'LEGAL', '*.indy']},
     include_package_data=True,
 
-    install_requires=['indy-node==1.13.2.dev1678195950', 'sovtoken==1.1.0.dev1678291666', 'sovtokenfees==1.1.0.dev1678291666'],
+    install_requires=['indy-node==1.13.2', 'sovtoken==1.1.0', 'sovtokenfees==1.1.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
              '*.css', '*.ico', '*.png', 'LICENSE', 'LEGAL', '*.indy']},
     include_package_data=True,
 
-    install_requires=['indy-node==1.13.2', 'sovtoken==1.1.0', 'sovtokenfees==1.1.0'],
+    install_requires=['indy-node==1.13.2', 'sovtoken==1.1.1', 'sovtokenfees==1.1.1'],
 )


### PR DESCRIPTION
This PR combines the indy-node and token-plugin changes from:
- https://github.com/sovrin-foundation/sovrin/pull/354
- https://github.com/sovrin-foundation/sovrin/pull/355
- https://github.com/sovrin-foundation/sovrin/pull/357

and includes updates to the version of the GitHub actions used by the workflows.